### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,7 +48,8 @@ def upload_file():
                 'transcription': result['text']
             })
         except Exception as e:
-            return jsonify({'error': str(e)}), 500
+            app.logger.error("An error occurred during file processing: %s", e, exc_info=True)
+            return jsonify({'error': 'An internal error has occurred. Please try again later.'}), 500
     
     return jsonify({'error': 'Invalid file type'}), 400
 


### PR DESCRIPTION
Potential fix for [https://github.com/chet-kamiwaza/whisper_transcriber/security/code-scanning/2](https://github.com/chet-kamiwaza/whisper_transcriber/security/code-scanning/2)

To fix the issue, we should avoid exposing the exception details to the user. Instead, we can log the exception details on the server for debugging purposes and return a generic error message to the user. This ensures that sensitive information is not leaked while still allowing developers to diagnose issues using server logs. The changes will involve replacing the `str(e)` in the JSON response with a generic error message and adding a logging mechanism to capture the exception details.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
